### PR TITLE
Support SteamLaunch argument being in any position

### DIFF
--- a/steam-launch.sh
+++ b/steam-launch.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # epoch-update.sh Steam launch shim adapted from BepInEx's launch shim
 #
 # HOW TO USE:
@@ -7,16 +7,6 @@
 
 SCRIPT_PATH="$(readlink -f "$0")"
 BASEDIR="$(dirname "$SCRIPT_PATH")"
-
-# Special case: launched via Steam
-if [ "$2" = "SteamLaunch" ]; then
-    cmd="$1 $2 $3 $4 $0"
-    shift 4
-    exec $cmd "$@"
-    exit
-fi
-
-# Path to updater script (assumed in same dir as this shim)
 UPDATER="$BASEDIR/epoch-update.sh"
 
 # Ensure the updater is executable
@@ -24,6 +14,17 @@ if [ ! -x "$UPDATER" ]; then
     echo "Error: epoch-update.sh not found or not executable in $BASEDIR"
     exit 1
 fi
+
+args=("$@")
+for i in "${!args[@]}"; do
+    if [ "${args[$i]}" = "SteamLaunch" ]; then
+        # Insert $0 at position i+3 (two after SteamLaunch)
+        insert_pos=$((i + 3))
+        new_args=("${args[@]:0:$insert_pos}" "$0" "${args[@]:$insert_pos}")
+        exec "${new_args[@]}"
+        exit
+    fi
+done
 
 # Run the updater
 "$UPDATER"


### PR DESCRIPTION
SteamLaunch being the $2 argument may be true in some circumstances. But I cannot reproduce this, on SteamDeck or on NixOS. 

What I believe has happened is that when running using the steamruntime (which previously only was forced on steamdeck) the arguments are different, so the previous method doesn't work. I believe this is now forced for all steam on linux users. IIRC it happened earlier this year, or late last year. I did try to just change which argument it looked for SteamLaunch, and also change which arguments are stored and shifted, but it got too confusing and I decided to come up with a better solution.

This new method looks for the SteamLaunch argument, and then basically does the same thing the previous method did, but now places the shim in the correct position in the argument list relative to SteamLaunch, dynamically.

Why have this change instead of just removing the faulty check that possibly never succeeds?

This will put the execution of the script in a different part of the process hierarchy. This wasn't really needed before, but if we want to be able to use programs like zenity on steamdeck, we need to execute inside gamescope, and not before it.