### PR TITLE
send done notification

### DIFF
--- a/epoch-update.sh
+++ b/epoch-update.sh
@@ -572,6 +572,8 @@ stdout "$CURRENT files already up to date."
 if [[ -n "$GUI_MODE" ]]; then
     gui_progress_update "100"
     gui_status_update "Done!"
+else
+    notify_status "Done. $UPDATED files updated"
 fi
 
 cleanup


### PR DESCRIPTION
If not in GUI mode send a "Done. N files update" notification.

I have been using `epoch-update.sh --notifications` as my pre launch script (have been avoiding `--gui` because `zenity` doesn't ship in the Bottles flatpak by default. But that's a problem for a different time :smile:)

In summary, it allows a similar "done" feedback via notification if not using the GUI flags.

Hope that makes sense and thank you for the script!